### PR TITLE
Move Web3Privacy link to its own line

### DIFF
--- a/index.html
+++ b/index.html
@@ -902,7 +902,7 @@
           </ul>
           <ul id="links01" class="links">
             <li class="n01"><a href="https://waku.org/">Powered by Waku</a></li>
-            <li class="n02">
+            <li class="n02" style="width: 100%">
               <a
                 href="https://github.com/web3privacy/hackathon-2025-berlin-submissions?tab=readme-ov-file#-winning-projects-7"
                 >Winner of Web3Privacy hackthon 2025 @ Berlin</a


### PR DESCRIPTION
## Summary
- update layout so the Web3Privacy Hackathon link appears below "Powered by Waku"

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686b4c30926c8329b5f0ba8266da718f