### PR TITLE
Update canonical links for Aside

### DIFF
--- a/index.html
+++ b/index.html
@@ -792,21 +792,12 @@
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="899" />
     <meta property="og:image:height" content="1200" />
-    <meta property="og:url" content="https://stepaside.carrd.co" />
+    <meta property="og:url" content="https://aside.cc" />
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:image" content="./Aside_files/aside-preview.png" />
-    <link rel="canonical" href="https://stepaside.carrd.co/" />
+    <link rel="canonical" href="https://aside.cc/" />
     <link href="./Aside_files/css2" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="style.css" />
-    <link
-      rel="icon"
-      type="image/png"
-      href="https://stepaside.carrd.co/assets/images/favicon.png?v=a6bbd45d"
-    />
-    <link
-      rel="apple-touch-icon"
-      href="https://stepaside.carrd.co/assets/images/apple-touch-icon.png?v=a6bbd45d"
-    />
     ><svg
       xmlns="http://www.w3.org/2000/svg"
       version="1.1"


### PR DESCRIPTION
## Summary
- clean old stepaside.carrd.co references from `index.html`
- remove dead favicon references

## Testing
- `grep -n aside.cc index.html`


------
https://chatgpt.com/codex/tasks/task_e_686b56aa8cec83298050cd2f52460ec0